### PR TITLE
fix: enable DockerHub login by default in pipeline configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After that, in Azure DevOps a new pipeline has to be created from this file.
 | spotBugsEnabled | Specifies whether SpotBugs analysis should be enabled. | false |  |
 | spotBugsPluginVersion | Specifies the version of the SpotBugs plugin to be used for code analysis. | 4.7.0 |  |
 | javaVersion | Specifies the JDK version to make available on the path. Use a whole number version, such as 17 or 21. | 17 | Yes |
-| dockerhubLogin | Specifies whether to perform a DockerHub login before the build steps. | false |  |
+| dockerhubLogin | Specifies whether to perform a DockerHub login before the build steps. | true |  |
 | dockerhubServiceConnection | Name of the DockerHub registry service connection to use for login. | '$(DOCKERHUB_PUBLIC_SERVICE_CONNECTION)' | Only when `dockerhubLogin` is true |
 | templateRepository | Resource name of this template repository. | icm-partner-devops | Yes |
 

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -176,7 +176,7 @@ parameters:
   # Specifies whether to perform a DockerHub login before the build steps.
 - name: dockerhubLogin
   type: boolean
-  default: false
+  default: true
 
   # Name of the DockerHub registry service connection to use for login.
 - name: dockerhubServiceConnection


### PR DESCRIPTION
- The `dockerhubLogin` parameter is set to true by default. This is mandatory because some builds hit the Docker Hub pull rate limit.
